### PR TITLE
Update setup.py for v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='nimbella',
-    version='1.0.0',
+    version='2.0.0',
     author='Nimbella Corporation',
     author_email='info@nimbella.com',
-    description='A python package to interact with nimbella.com services.',
+    description='A python package to interact with Nimbella cloud services.',
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/nimbella/nimbella-sdk-python",


### PR DESCRIPTION
The publish action is failing:
```
Checking dist/nimbella-1.0.0-py2.py3-none-any.whl: PASSED
Checking dist/nimbella-1.0.0.tar.gz: PASSED
Uploading distributions to https://upload.pypi.org/legacy/
Uploading nimbella-1.0.0-py2.py3-none-any.whl

HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
File already exists. See https://pypi.org/help/#file-name-reuse for more information.
```

I believe this is because the version wasn't bumped when the 2.0.0 tag was issued.
I suggest deleting and retagging after this commit.