### PR TITLE
Change the bucket naming to include deployment

### DIFF
--- a/nimbella/storage/plugins/aws_storage_plugin.py
+++ b/nimbella/storage/plugins/aws_storage_plugin.py
@@ -95,7 +95,7 @@ class AWSStoragePlugin(AbstractStoragePlugin):
                 return self.credentials["weburl"]
             else:
                 hostname = urlparse(self.credentials["endpoint"]).netloc
-                return f"http://{self.namespace}-nimbella-io.{hostname}"
+                return f"http://{self.bucket_key}.{hostname}"
 
     def file(self, destination) -> S3StorageFile:
         return S3StorageFile(self.bucket.Object(destination), self.web, self.client.client('s3'))
@@ -128,4 +128,6 @@ class AWSStoragePlugin(AbstractStoragePlugin):
     @property
     def bucket_key(self):
         datapart = "" if self.web else "data-"
-        return f"{datapart}{self.namespace}-nimbella-io"
+        hostname = urlparse(self.apiHost).netloc
+        deployment = hostname.split(".")[0]
+        return f"{datapart}{self.namespace}-{deployment}-nimbella-io"

--- a/test/test_aws_storage_plugin.py
+++ b/test/test_aws_storage_plugin.py
@@ -21,28 +21,30 @@ class TestAWSStoragePlugin(unittest.TestCase):
         client = MagicMock()
         namespace = 'this-is-a-namespace'
         apiHost = 'https://this.is.a.host.com'
+        deployment = 'this'
 
         # test bucket keys for web buckets
         web = True
         aws = AWSStoragePlugin(client, namespace, apiHost, web, '')
-        self.assertEqual(aws.bucket_key, f'{namespace}-nimbella-io')
+        self.assertEqual(aws.bucket_key, f'{namespace}-{deployment}-nimbella-io')
 
         # test bucket keys for data buckets
         aws.web = False
-        self.assertEqual(aws.bucket_key, f'data-{namespace}-nimbella-io')
+        self.assertEqual(aws.bucket_key, f'data-{namespace}-{deployment}-nimbella-io')
 
     def test_bucket_url(self):
         # test happy path using bucket location in creds
         client = MagicMock()
         namespace = 'this-is-a-namespace'
         apiHost = 'https://this.is.a.host.com'
+        deployment = 'this'
         bucketHost = 'bucket.host.com'
         credentials = {
             "endpoint": f'https://{bucketHost}' 
         }
 
         aws = AWSStoragePlugin(client, namespace, apiHost, True, credentials)
-        self.assertEqual(aws.url, f'http://{namespace}-nimbella-io.{bucketHost}')
+        self.assertEqual(aws.url, f'http://{namespace}-{deployment}-nimbella-io.{bucketHost}')
 
         # Test bucket credentials contain weburl
         weburl = "http://some_other_address.com"


### PR DESCRIPTION
This is a necessary change to reflect a change in how buckets will be named in AWS deployments.   The previous naming scheme would have limited Nimbella to a single AWS deployment, since bucket names must be globally unique and each deployment is an independent scope for Nimbella namespace names.  There is no change to the GCS bucket naming: this change should only affect AWS.

@jthomas I called this a draft initially because (as we've discussed) I am having trouble getting a clean working version of python3 on my machine and have been unable to run the tests locally.   However, it appears the tests passed in the github workflow.

The timing of publication is unconstrained, assuming no regressions in GCS behavior, since we do not yet have hosted customers using AWS buckets.