### PR TITLE
setting the region with env vars

### DIFF
--- a/nimbella/storage/plugins/aws_storage_plugin.py
+++ b/nimbella/storage/plugins/aws_storage_plugin.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 
 import boto3
 import botocore
+import os
 
 # Simple wrapper around AWS S3 Object class to provide
 # generic "storage file" for this provider
@@ -71,6 +72,9 @@ class S3StorageFile(AbstractStorageFile):
 class AWSStoragePlugin(AbstractStoragePlugin):
     def __init__(self, client, namespace, apiHost, web, credentials):
         super().__init__(client, namespace, apiHost, web, credentials)
+        # workaround because the region is not specified in the credentials
+        # and cannot be added without breaking signatures
+        os.environ['AWS_DEFAULT_REGION'] = credentials['region']
         self.bucket = self.client.resource('s3').Bucket(self.bucket_key)
 
     @staticmethod

--- a/nimbella/storage/plugins/aws_storage_plugin.py
+++ b/nimbella/storage/plugins/aws_storage_plugin.py
@@ -74,7 +74,8 @@ class AWSStoragePlugin(AbstractStoragePlugin):
         super().__init__(client, namespace, apiHost, web, credentials)
         # workaround because the region is not specified in the credentials
         # and cannot be added without breaking signatures
-        os.environ['AWS_DEFAULT_REGION'] = credentials['region']
+        if 'region' in credentials:
+            os.environ['AWS_DEFAULT_REGION'] = credentials['region']
         self.bucket = self.client.resource('s3').Bucket(self.bucket_key)
 
     @staticmethod


### PR DESCRIPTION
this PR fixes bucket support not working in non us regions as the defaul region shold be specified (and it is not).

Note that this more obvious fix does not work because changing default creds breaks signatures:

```
# changes for class AWSStoragePlugin(AbstractStoragePlugin):

    @staticmethod
    def create_client(credentials: dict) ->  botocore.client.BaseClient:
        session = boto3.Session(
            aws_access_key_id=credentials['accessKeyId'],
            aws_secret_access_key=credentials['secretAccessKey'],
            region_name=credentials['region'])
        return session

    @staticmethod
    def create_client(credentials: dict) ->  botocore.client.BaseClient:
        session = boto3.Session(
            aws_access_key_id=credentials['accessKeyId'],
            aws_secret_access_key=credentials['secretAccessKey'],
            region_name=credentials['region'])
        return session
```