### PR TITLE
Change the name of the bucket to be in par with the changes on main repo

### DIFF
--- a/nimbella/storage/plugins/aws_storage_plugin.py
+++ b/nimbella/storage/plugins/aws_storage_plugin.py
@@ -129,5 +129,5 @@ class AWSStoragePlugin(AbstractStoragePlugin):
     def bucket_key(self):
         datapart = "" if self.web else "data-"
         hostname = urlparse(self.apiHost).netloc
-        deployment = hostname.split(".")[0]
-        return f"{datapart}{self.namespace}-{deployment}-nimbella-io"
+        deployment = hostname.replace(".", "-")
+        return f"{datapart}{self.namespace}-{deployment}"

--- a/test/test_aws_storage_plugin.py
+++ b/test/test_aws_storage_plugin.py
@@ -21,30 +21,30 @@ class TestAWSStoragePlugin(unittest.TestCase):
         client = MagicMock()
         namespace = 'this-is-a-namespace'
         apiHost = 'https://this.is.a.host.com'
-        deployment = 'this'
+        deployment = 'this-is-a-host-com'
 
         # test bucket keys for web buckets
         web = True
         aws = AWSStoragePlugin(client, namespace, apiHost, web, '')
-        self.assertEqual(aws.bucket_key, f'{namespace}-{deployment}-nimbella-io')
+        self.assertEqual(aws.bucket_key, f'{namespace}-{deployment}')
 
         # test bucket keys for data buckets
         aws.web = False
-        self.assertEqual(aws.bucket_key, f'data-{namespace}-{deployment}-nimbella-io')
+        self.assertEqual(aws.bucket_key, f'data-{namespace}-{deployment}')
 
     def test_bucket_url(self):
         # test happy path using bucket location in creds
         client = MagicMock()
         namespace = 'this-is-a-namespace'
         apiHost = 'https://this.is.a.host.com'
-        deployment = 'this'
+        deployment = 'this-is-a-host-com'
         bucketHost = 'bucket.host.com'
         credentials = {
             "endpoint": f'https://{bucketHost}' 
         }
 
         aws = AWSStoragePlugin(client, namespace, apiHost, True, credentials)
-        self.assertEqual(aws.url, f'http://{namespace}-{deployment}-nimbella-io.{bucketHost}')
+        self.assertEqual(aws.url, f'http://{namespace}-{deployment}.{bucketHost}')
 
         # Test bucket credentials contain weburl
         weburl = "http://some_other_address.com"


### PR DESCRIPTION
The name of the buckets needs to be changed from having the suffix `nimbella-io` to support Bring Your Own Domain feature where the client can get their custom domain names.

To be merged with [#2101](https://github.com/nimbella-corp/main/pull/2101) from the main repo